### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.8'
 services:
 
   db-data:
-    image: mysql:latest
+    image: mysql:8
     env_file:
      - .env
     environment:


### PR DESCRIPTION
Changed mysql image tag to "8" in order to follow docker best practices. 
Using the latest tag can result in an accidental major version switch bringing possible breaking changes.